### PR TITLE
Change first argument in Library.fgets to 'pointer': fixes TypeError on OSX

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ var libc = ffi.Library(null, {
   pclose: ['void', [ 'pointer']],
 
   // char* fgets(char* buff, int buff, in)
-  fgets: ['string', ['string', 'int','pointer']],
+  fgets: ['string', ['pointer', 'int','pointer']],
 
   system: ['int32', ['string']]
 });


### PR DESCRIPTION
lib.fgets was expecting a string, but Buffer(1024) is not. Curious to know why this didn't break for others ...?
#### Original Error

```
TypeError: error setting argument 0 - Argument must be a string
      at Object.allocCString (/Users/billy/projects/docco-plus/node_modules/ffi/node_modules/ref/lib/ref.js:539:21)
      at Object.set (/Users/billy/projects/docco-plus/node_modules/ffi/node_modules/ref/lib/ref.js:1036:26)
      at Object.set (/Users/billy/projects/docco-plus/node_modules/ffi/node_modules/ref/lib/ref.js:479:10)
      at Object.alloc (/Users/billy/projects/docco-plus/node_modules/ffi/node_modules/ref/lib/ref.js:513:13)
      at Object.proxy (/Users/billy/projects/docco-plus/node_modules/ffi/lib/_foreign_function.js:50:22)
      at Utils.sync_exec (/Users/billy/projects/docco-plus/lib/docco-plus.js:92:19)
      at Utils.__bind [as sync_exec] (/Users/bill/projects/docco-plus/lib/docco-plus.js:4:61)
      at Utils.build_files (/Users/billy/projects/docco-plus/lib/docco-plus.js:74:21)
      at Context.ext (/Users/billy/projects/docco-plus/tests/parser_tests.coffee:30:21)
      at Test.Runnable.run (/usr/local/share/npm/lib/node_modules/mocha/lib/runnable.js:213:32)
      at Runner.runTest (/usr/local/share/npm/lib/node_modules/mocha/lib/runner.js:343:10)
      at Runner.runTests.next (/usr/local/share/npm/lib/node_modules/mocha/lib/runner.js:389:12)
      at next (/usr/local/share/npm/lib/node_modules/mocha/lib/runner.js:269:14)
      at Runner.hooks (/usr/local/share/npm/lib/node_modules/mocha/lib/runner.js:278:7)
      at next (/usr/local/share/npm/lib/node_modules/mocha/lib/runner.js:226:23)
      at Runner.hook (/usr/local/share/npm/lib/node_modules/mocha/lib/runner.js:246:5)
      at process.startup.processNextTick.process._tickCallback (node.js:244:9)

```
#### Test case example

```
cmd = "find node_modules/ tests lib  -name '*.coffee'  -o  -name '*.js'  -o  -name '*.rb'  -o  -name '*.py'  -o  -name '*.java'  -o  -name '*.pp' "
execSync( cmd );

```
#### OS:

```
Darwin Williams-MacBook-Air.local 12.2.1 Darwin Kernel Version 12.2.1: Thu Oct 18 16:32:48 PDT 2012; root:xnu-2050.20.9~2/RELEASE_X86_64 x86_64
```
