### PR TITLE
add repository field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,9 @@
   "scripts": {
     "test": "mocha test/unixSpec",
     "install": "node install.js"
+  },
+  "repository": {
+    "type" : "git",
+    "url" : "https://github.com/mgutz/execSync.git"
   }
 }


### PR DESCRIPTION
it can help to make npm install no warning

> npm WARN package.json execSync@0.0.4 No repository field.
