### PR TITLE
Work around NodeJS bug involving path extensions

### DIFF
--- a/install.js
+++ b/install.js
@@ -2,10 +2,14 @@ var spawn = require('child_process').spawn;
 var fs = require('fs');
 var version = JSON.parse(fs.readFileSync(__dirname + '/package.json', 'utf8')).version;
 var verbose = process.env['npm_package_config_verbose'] != null ? process.env['npm_package_config_verbose'] === 'true' : false;
+var isWindows = require('os').platform().indexOf('win') === 0;
 
 console.log('[execsync v%s] Attempting to compile native extensions.', version);
 
-var gyp = spawn('node-gyp', ['rebuild'], {cwd: __dirname});
+// While node-gyp is runnable in Windows from the command line as `node-gyp`,
+// it's actually defined in the file `node-gyp.cmd`.
+// Relevant bug: https://github.com/joyent/node/issues/2318
+var gyp = spawn(isWindows ? 'node-gyp.cmd' : 'node-gyp', ['rebuild'], {cwd: __dirname});
 gyp.stdout.on('data', function(data) {
   if (verbose) process.stdout.write(data);
 });


### PR DESCRIPTION
execSync fails to install in Windows because node-gyp is actually defined in a file named 'node-gyp.cmd', triggering an ENOENT when `spawn` runs.

Relevant NodeJS bug:
https://github.com/joyent/node/issues/2318
